### PR TITLE
Fix duplicate pin

### DIFF
--- a/raw/esp32s2/Wemos_Teleinfo/init.bat
+++ b/raw/esp32s2/Wemos_Teleinfo/init.bat
@@ -1,4 +1,4 @@
-Template {"NAME":"Wemos Teleinfo","GPIO":[1,1,1,1,1,1,1,1376,1,1,1,5632,1,1,1,1,1,1,1,5632,1,1,640,1,608,1,0,1,1,1,1,1,1,1,1,1],"FLAG":0,"BASE":1}
+Template {"NAME":"Wemos Teleinfo","GPIO":[1,1,1,1,1,1,1,1376,1,1,1,5632,1,1,1,1,1,1,1,1,1,1,640,1,608,1,0,1,1,1,1,1,1,1,1,1],"FLAG":0,"BASE":1}
 Module 0
 
 ; All these parameters are saved onto flash device


### PR DESCRIPTION
Since the template had component 5632 `TInfo RX` twice, on both gpio 15 and 23, I'm removing the latter, as Tasmota would be using the former, and I guess that the duplication came from modifying the "classic" ESP32 template to fit, where `TInfo RX` was already on gpio 23.