### PR TITLE
Shelly Plus 1PM on-device Button

### DIFF
--- a/raw/esp32/Shelly_Plus_1PM/init.bat
+++ b/raw/esp32/Shelly_Plus_1PM/init.bat
@@ -1,4 +1,4 @@
 Br load("Shelly_Plus_1PM.autoconf#migrate_shelly.be")
-Template {"NAME":"Shelly Plus 1PM","GPIO":[0,0,0,0,192,2720,0,0,0,0,0,0,0,0,2656,0,0,0,0,2624,0,160,224,0,0,0,0,0,4736,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}
+Template {"NAME":"Shelly Plus 1PM","GPIO":[0,0,0,0,192,2720,0,0,0,0,0,0,0,0,2656,0,0,0,0,2624,0,32,224,0,0,0,0,0,4736,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}
 Module 0
 AdcParam1 2,10000,10000,3350


### PR DESCRIPTION
Better config the small on-device push button as a Button input, instead of "Switch" with same index as used for the primary mains voltage SW input (Switch_n).