### PR TITLE
TELEINFO: DENKY: Uniform teleinfo configuration on all devices

### DIFF
--- a/raw/esp32/DenkyD4_V1.0/_autoexec.be
+++ b/raw/esp32/DenkyD4_V1.0/_autoexec.be
@@ -1,0 +1,28 @@
+# This file does nothing it just contains some
+# examples to suit your needs depending on project
+# It will be copied into filesystem to be editable
+# =====================================================
+
+# Set auto timezone
+#tasmota.cmd("Backlog0 Timezone 99; TimeStd 0,0,10,1,3,60; TimeDst 0,0,3,1,2,120")
+
+# Set Teleinfo in legacy (historique) mode at 1200 baud.
+#tasmota.cmd("EnergyConfig Historique")
+
+# Set Teleinfo in Standar mode at 9600 baud.
+#tasmota.cmd("EnergyConfig Standard")
+
+# Set Teleinfo to autodetect mode (standard or historique)
+#tasmota.cmd("EnergyConfig automode")
+
+# Set LED brightness to 75%, in sleep mode it will be bright/2
+# 0 for Green LED and 1 for Period Indicator (blue, white or red)
+#tasmota.cmd("EnergyConfig bright=75")
+#tasmota.cmd("EnergyConfig period=1")
+
+# Disable Boot Loop Detection
+#tasmota.cmd("SetOption65 1")
+
+# Avoid conflict between native WS2812 and Berry control
+# disables native WS2812 (default Scheme is 0)
+#tasmota.cmd("Scheme 14")

--- a/raw/esp32/DenkyD4_V1.0/cp2fs.be
+++ b/raw/esp32/DenkyD4_V1.0/cp2fs.be
@@ -1,0 +1,33 @@
+# Copy teleinfo driver to file system to be end user editable
+
+# simple function to copy from autoconfig archive to filesystem
+# return true if ok
+def cp(from, to)
+  import path
+  if to == nil    to = from   end     # to is optional
+  tasmota.log("OTA: copying "+tasmota.wd + to, 2)
+  if !path.exists(to)
+    try
+      # tasmota.log("f_in="+tasmota.wd + from)
+      var f_in = open(tasmota.wd + from)
+      var f_content = f_in.readbytes()
+      f_in.close()
+      var f_out = open(to, "w")
+      f_out.write(f_content)
+      f_out.close()
+    except .. as e,m
+      tasmota.log("OTA: Couldn't copy "+to+" "+e+" "+m,2)
+      return false
+    end
+    return true
+  end
+  return true
+end
+
+import path
+
+# copy some samples files from autoconf 
+# to filesystem for end user speed up learn
+cp("_autoexec.be", "autoexec.be")
+
+# Done

--- a/raw/esp32/DenkyD4_V1.0/init.bat
+++ b/raw/esp32/DenkyD4_V1.0/init.bat
@@ -1,30 +1,50 @@
-Template {"NAME":"Denky D4 (v1.0)","GPIO":[32,3200,0,3232,1,0,0,0,0,1,0,1,0,0,0,0,0,640,608,0,0,450,449,448,0,0,5632,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}
+; Generic Teleinfo
+; ----------------
 
-; All these parameters are saved onto flash device
-; only once when autoconf is activated or 
-; when it's removed and activated again
-; ===================================================
+; copy some samples to FS
+Br load("DenkyD4_V1.3a.autoconf#cp2fs.be")
+
+; Reset settings, but preserve wifi, MQTT and FS
+InitDevice 6
+
+; Disable analog values display
+WebSensor2 0
+
+; Disable energy values display
+WebSensor3 0
 
 ; Disable Boot Loop Detection
 SetOption65 1
 
-; define OTA Url
+; Enable Wifi Scan (avoid wifi lost if router change channel)
+SetOption56 1
+
+; Set WebRefresh to 1 second
+WebRefresh 1000
+
+; Set auto timezone
+Backlog Timezone 99; TimeStd 0,0,10,1,3,60; TimeDst 0,0,3,1,2,120;
+
+; Set blinking LED color : 0 for Green LED and 1 for Period Indicator (blue, white or red)
+; Set Teleinfo to autodetect mode 
+Energyconfig period=1 reset
+
+; Denky D4
+; --------
+
+; Set module configuration
+Template {"NAME":"Denky D4 (v1.0)","GPIO":[32,3200,0,3232,1,0,0,0,0,1,0,1,0,0,0,0,0,640,608,0,0,450,449,448,0,0,5632,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}
+
+; Set LED brightness to 75%, in sleep mode it will be bright/2
+Energyconfig bright=75
+
+; OTA Url
 OtaUrl https://github.com/NicolasBernaerts/tasmota/raw/master/teleinfo/binary/tasmota32-teleinfo-denkyd4.bin
 
-; # Set auto timezone
-Backlog0 Timezone 99; TimeStd 0,0,10,1,3,60; TimeDst 0,0,3,1,2,120
-
-; # Set Teleinfo in legacy (historique) mode at 1200 baud.
-; EnergyConfig Historique	
-
-; # Set Teleinfo in stadard mode at 9600 baud.
-; EnergyConfig Standard
-
-; Set Teleinfo to autodetect mode 
-Energyconfig reset 
-
 ; Set serial log output to info on uart0 (log to onboard USB/Serial)
-Backlog SerialConfig 8N1; Baudrate 115200; SerialLog 2
+Backlog SerialConfig 8N1; Baudrate 115200; SerialLog 2;
 
-; use template and reboot
+; Set default module
 Module 0
+
+

--- a/raw/esp32/DenkyD4_V1.0/init.bat
+++ b/raw/esp32/DenkyD4_V1.0/init.bat
@@ -1,9 +1,6 @@
 ; Generic Teleinfo
 ; ----------------
 
-; copy some samples to FS
-Br load("DenkyD4_V1.3a.autoconf#cp2fs.be")
-
 ; Reset settings, but preserve wifi, MQTT and FS
 InitDevice 6
 
@@ -31,6 +28,9 @@ Energyconfig period=1 reset
 
 ; Denky D4
 ; --------
+
+; copy some samples to FS
+Br load("DenkyD4_V1.0.autoconf#cp2fs.be")
 
 ; Set module configuration
 Template {"NAME":"Denky D4 (v1.0)","GPIO":[32,3200,0,3232,1,0,0,0,0,1,0,1,0,0,0,0,0,640,608,0,0,450,449,448,0,0,5632,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}

--- a/raw/esp32/DenkyD4_V1.1/init.bat
+++ b/raw/esp32/DenkyD4_V1.1/init.bat
@@ -1,42 +1,50 @@
-Br load("DenkyD4_V1.1.autoconf#cp2fs.be")
-Template {"NAME":"Denky D4 (v1.3a)","GPIO":[32,3200,0,3232,1,0,0,0,0,1,1376,1,0,0,0,0,0,640,608,0,0,0,0,0,0,0,5632,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}
+; Generic Teleinfo
+; ----------------
 
-; All these parameters are saved onto flash device
-; only once when autoconf is activated or 
-; when it's removed and activated again
-; ===================================================
+; copy some samples to FS
+Br load("DenkyD4_V1.3a.autoconf#cp2fs.be")
+
+; Reset settings, but preserve wifi, MQTT and FS
+InitDevice 6
+
+; Disable analog values display
+WebSensor2 0
+
+; Disable energy values display
+WebSensor3 0
 
 ; Disable Boot Loop Detection
 SetOption65 1
 
-; define OTA Url
-OtaUrl https://github.com/NicolasBernaerts/tasmota/raw/master/teleinfo/binary/tasmota32-teleinfo-denkyd4.bin
+; Enable Wifi Scan (avoid wifi lost if router change channel)
+SetOption56 1
+
+; Set WebRefresh to 1 second
+WebRefresh 1000
 
 ; Set auto timezone
-Backlog0 Timezone 99; TimeStd 0,0,10,1,3,60; TimeDst 0,0,3,1,2,120
+Backlog Timezone 99; TimeStd 0,0,10,1,3,60; TimeDst 0,0,3,1,2,120;
 
-; Set Teleinfo in legacy (historique) mode at 1200 baud.
-; EnergyConfig Historique	
+; Set blinking LED color : 0 for Green LED and 1 for Period Indicator (blue, white or red)
+; Set Teleinfo to autodetect mode 
+Energyconfig period=1 reset
 
-; Set Teleinfo in standard mode at 9600 baud.
-; EnergyConfig Standard
+; Denky D4
+; --------
+
+; Set module configuration
+Template {"NAME":"Denky D4 (v1.3a)","GPIO":[32,3200,0,3232,1,0,0,0,0,1,1376,1,0,0,0,0,0,640,608,0,0,0,0,0,0,0,5632,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}
 
 ; Set LED brightness to 75%, in sleep mode it will be bright/2
 Energyconfig bright=75
 
-; 0 for Green LED and 1 for Period Indicator (blue, white or red)
-Energyconfig period=1 
-
-; Set Teleinfo to autodetect mode (standard or historique)
-; old firmware commnand, deprecated
-; Energyconfig automode 
-
-; Set Teleinfo to autodetect mode (standard or historique)
-Energyconfig reset 
+; OTA Url
+OtaUrl https://github.com/NicolasBernaerts/tasmota/raw/master/teleinfo/binary/tasmota32-teleinfo-denkyd4.bin
 
 ; Set serial log output to info on uart0 (log to onboard USB/Serial)
-Backlog SerialConfig 8N1; Baudrate 115200; SerialLog 2
+Backlog SerialConfig 8N1; Baudrate 115200; SerialLog 2;
 
-; use template and reboot
+; Set default module
 Module 0
+
 

--- a/raw/esp32/DenkyD4_V1.1/init.bat
+++ b/raw/esp32/DenkyD4_V1.1/init.bat
@@ -1,9 +1,6 @@
 ; Generic Teleinfo
 ; ----------------
 
-; copy some samples to FS
-Br load("DenkyD4_V1.3a.autoconf#cp2fs.be")
-
 ; Reset settings, but preserve wifi, MQTT and FS
 InitDevice 6
 
@@ -32,8 +29,11 @@ Energyconfig period=1 reset
 ; Denky D4
 ; --------
 
+; copy some samples to FS
+Br load("DenkyD4_V1.1.autoconf#cp2fs.be")
+
 ; Set module configuration
-Template {"NAME":"Denky D4 (v1.3a)","GPIO":[32,3200,0,3232,1,0,0,0,0,1,1376,1,0,0,0,0,0,640,608,0,0,0,0,0,0,0,5632,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}
+Template {"NAME":"Denky D4 (v1.1)","GPIO":[32,3200,0,3232,1,0,0,0,0,1,1376,1,0,0,0,0,0,640,608,0,0,0,0,0,0,0,5632,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}
 
 ; Set LED brightness to 75%, in sleep mode it will be bright/2
 Energyconfig bright=75

--- a/raw/esp32/DenkyD4_V1.3/init.bat
+++ b/raw/esp32/DenkyD4_V1.3/init.bat
@@ -1,41 +1,50 @@
-Br load("DenkyD4_V1.3.autoconf#cp2fs.be")
-Template {"NAME":"Denky D4 (v1.3a)","GPIO":[32,3200,0,3232,1,0,0,0,0,1,1376,1,0,0,0,0,0,640,608,0,0,0,0,0,0,0,5632,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}
+; Generic Teleinfo
+; ----------------
 
-; All these parameters are saved onto flash device
-; only once when autoconf is activated or 
-; when it's removed and activated again
-; ===================================================
+; copy some samples to FS
+Br load("DenkyD4_V1.3a.autoconf#cp2fs.be")
+
+; Reset settings, but preserve wifi, MQTT and FS
+InitDevice 6
+
+; Disable analog values display
+WebSensor2 0
+
+; Disable energy values display
+WebSensor3 0
 
 ; Disable Boot Loop Detection
 SetOption65 1
 
-; define OTA Url
-OtaUrl https://github.com/NicolasBernaerts/tasmota/raw/master/teleinfo/binary/tasmota32-teleinfo-denkyd4.bin
+; Enable Wifi Scan (avoid wifi lost if router change channel)
+SetOption56 1
+
+; Set WebRefresh to 1 second
+WebRefresh 1000
 
 ; Set auto timezone
-Backlog0 Timezone 99; TimeStd 0,0,10,1,3,60; TimeDst 0,0,3,1,2,120
+Backlog Timezone 99; TimeStd 0,0,10,1,3,60; TimeDst 0,0,3,1,2,120;
 
-; Set Teleinfo in legacy (historique) mode at 1200 baud.
-; EnergyConfig Historique	
+; Set blinking LED color : 0 for Green LED and 1 for Period Indicator (blue, white or red)
+; Set Teleinfo to autodetect mode 
+Energyconfig period=1 reset
 
-; Set Teleinfo in standard mode at 9600 baud.
-; EnergyConfig Standard
+; Denky D4
+; --------
+
+; Set module configuration
+Template {"NAME":"Denky D4 (v1.3a)","GPIO":[32,3200,0,3232,1,0,0,0,0,1,1376,1,0,0,0,0,0,640,608,0,0,0,0,0,0,0,5632,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}
 
 ; Set LED brightness to 75%, in sleep mode it will be bright/2
 Energyconfig bright=75
 
-; 0 for Green LED and 1 for Period Indicator (blue, white or red)
-Energyconfig period=1 
-
-; Set Teleinfo to autodetect mode (standard or historique)
-; old firmware commnand, deprecated
-; Energyconfig automode 
-
-; Set Teleinfo to autodetect mode (standard or historique)
-Energyconfig reset
+; OTA Url
+OtaUrl https://github.com/NicolasBernaerts/tasmota/raw/master/teleinfo/binary/tasmota32-teleinfo-denkyd4.bin
 
 ; Set serial log output to info on uart0 (log to onboard USB/Serial)
-Backlog SerialConfig 8N1; Baudrate 115200; SerialLog 2
+Backlog SerialConfig 8N1; Baudrate 115200; SerialLog 2;
 
-; use template and reboot
+; Set default module
 Module 0
+
+

--- a/raw/esp32/DenkyD4_V1.3/init.bat
+++ b/raw/esp32/DenkyD4_V1.3/init.bat
@@ -1,9 +1,6 @@
 ; Generic Teleinfo
 ; ----------------
 
-; copy some samples to FS
-Br load("DenkyD4_V1.3a.autoconf#cp2fs.be")
-
 ; Reset settings, but preserve wifi, MQTT and FS
 InitDevice 6
 
@@ -32,8 +29,11 @@ Energyconfig period=1 reset
 ; Denky D4
 ; --------
 
+; copy some samples to FS
+Br load("DenkyD4_V1.3.autoconf#cp2fs.be")
+
 ; Set module configuration
-Template {"NAME":"Denky D4 (v1.3a)","GPIO":[32,3200,0,3232,1,0,0,0,0,1,1376,1,0,0,0,0,0,640,608,0,0,0,0,0,0,0,5632,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}
+Template {"NAME":"Denky D4 (v1.3)","GPIO":[32,3200,0,3232,1,0,0,0,0,1,1376,1,0,0,0,0,0,640,608,0,0,0,0,0,0,0,5632,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}
 
 ; Set LED brightness to 75%, in sleep mode it will be bright/2
 Energyconfig bright=75

--- a/raw/esp32/DenkyD4_V1.3a/init.bat
+++ b/raw/esp32/DenkyD4_V1.3a/init.bat
@@ -1,42 +1,50 @@
-Br load("DenkyD4_V1.3a.autoconf#cp2fs.be")
-Template {"NAME":"Denky D4 (v1.3a)","GPIO":[32,3200,0,3232,1,0,0,0,0,1,1376,1,0,0,0,0,0,640,608,0,0,0,0,0,0,0,5632,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}
+; Generic Teleinfo
+; ----------------
 
-; All these parameters are saved onto flash device
-; only once when autoconf is activated or 
-; when it's removed and activated again
-; ===================================================
+; copy some samples to FS
+Br load("DenkyD4_V1.3a.autoconf#cp2fs.be")
+
+; Reset settings, but preserve wifi, MQTT and FS
+InitDevice 6
+
+; Disable analog values display
+WebSensor2 0
+
+; Disable energy values display
+WebSensor3 0
 
 ; Disable Boot Loop Detection
 SetOption65 1
 
-; define OTA Url
-OtaUrl https://github.com/NicolasBernaerts/tasmota/raw/master/teleinfo/binary/tasmota32-teleinfo-denkyd4.bin
+; Enable Wifi Scan (avoid wifi lost if router change channel)
+SetOption56 1
+
+; Set WebRefresh to 1 second
+WebRefresh 1000
 
 ; Set auto timezone
-Backlog0 Timezone 99; TimeStd 0,0,10,1,3,60; TimeDst 0,0,3,1,2,120
+Backlog Timezone 99; TimeStd 0,0,10,1,3,60; TimeDst 0,0,3,1,2,120;
 
-; Set Teleinfo in legacy (historique) mode at 1200 baud.
-; EnergyConfig Historique	
+; Set blinking LED color : 0 for Green LED and 1 for Period Indicator (blue, white or red)
+; Set Teleinfo to autodetect mode 
+Energyconfig period=1 reset
 
-; Set Teleinfo in standard mode at 9600 baud.
-; EnergyConfig Standard
+; Denky D4
+; --------
+
+; Set module configuration
+Template {"NAME":"Denky D4 (v1.3a)","GPIO":[32,3200,0,3232,1,0,0,0,0,1,1376,1,0,0,0,0,0,640,608,0,0,0,0,0,0,0,5632,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}
 
 ; Set LED brightness to 75%, in sleep mode it will be bright/2
 Energyconfig bright=75
 
-; 0 for Green LED and 1 for Period Indicator (blue, white or red)
-Energyconfig period=1 
-
-; Set Teleinfo to autodetect mode (standard or historique)
-; old firmware commnand, deprecated
-; Energyconfig automode 
-
-; Set Teleinfo to autodetect mode (standard or historique)
-Energyconfig reset 
+; OTA Url
+OtaUrl https://github.com/NicolasBernaerts/tasmota/raw/master/teleinfo/binary/tasmota32-teleinfo-denkyd4.bin
 
 ; Set serial log output to info on uart0 (log to onboard USB/Serial)
-Backlog SerialConfig 8N1; Baudrate 115200; SerialLog 2
+Backlog SerialConfig 8N1; Baudrate 115200; SerialLog 2;
 
-; use template and reboot
+; Set default module
 Module 0
+
 

--- a/raw/esp32/DenkyD4_V1.3a/init.bat
+++ b/raw/esp32/DenkyD4_V1.3a/init.bat
@@ -1,9 +1,6 @@
 ; Generic Teleinfo
 ; ----------------
 
-; copy some samples to FS
-Br load("DenkyD4_V1.3a.autoconf#cp2fs.be")
-
 ; Reset settings, but preserve wifi, MQTT and FS
 InitDevice 6
 
@@ -31,6 +28,9 @@ Energyconfig period=1 reset
 
 ; Denky D4
 ; --------
+
+; copy some samples to FS
+Br load("DenkyD4_V1.3a.autoconf#cp2fs.be")
 
 ; Set module configuration
 Template {"NAME":"Denky D4 (v1.3a)","GPIO":[32,3200,0,3232,1,0,0,0,0,1,1376,1,0,0,0,0,0,640,608,0,0,0,0,0,0,0,5632,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}


### PR DESCRIPTION
Uniform teleinfo configuration on all devices
Change order of init command because some that require reset set a flag that can trigger reset 250ms after,  and if all is not finished, the end of init.bat is never executed thanks to [@NicolasBernaerts](https://github.com/NicolasBernaerts)