### PR TITLE
TELEINFO: OLIMEX: uniform teleinfo init.bat for all devices

### DIFF
--- a/raw/esp32/EthTinfo_V1.0/init.bat
+++ b/raw/esp32/EthTinfo_V1.0/init.bat
@@ -1,36 +1,51 @@
+; Generic Teleinfo
+; ----------------
+
+; Reset settings, but preserve wifi, MQTT and FS
+InitDevice 6
+
+; Disable analog values display
+WebSensor2 0
+
+; Disable energy values display
+WebSensor3 0
+
+; Disable Boot Loop Detection
+SetOption65 1
+
+; Enable Wifi Scan (avoid wifi lost if router change channel)
+SetOption56 1
+
+; Set WebRefresh to 1 second
+WebRefresh 1000
+
+; Set auto timezone
+Backlog Timezone 99; TimeStd 0,0,10,1,3,60; TimeDst 0,0,3,1,2,120;
+
+; Set blinking LED color : 0 for Green LED and 1 for Period Indicator (blue, white or red)
+; Set Teleinfo to autodetect mode 
+Energyconfig period=1 reset
+
+; EthTinfo
+; --------
+
+; Set module configuration
 Template {"NAME":"EthTinfo (Olimex ESP32)","GPIO":[1,1,8864,1,0,1,0,0,5536,1,8832,8800,0,0,5600,1,1,1,1,5568,1,1,1,1,0,0,0,0,1,1,32,1,5632,1,1,1],"FLAG":0,"BASE":1}
 Module 0
 EthType 0
 EthAddress 0
 EthClockMode 3
 
-; All these parameters are saved onto flash device
-; so once configured, you can change them afterward
-; in the file autoexec.be copied onto the filesystem
-; =====================================================
+; Set LED brightness to 75%, in sleep mode it will be bright/2
+Energyconfig bright=75
 
-; Disable Boot Loop Detection
-SetOption65 1
-
-; define OTA Url
+; OTA Url
 OtaUrl https://github.com/NicolasBernaerts/tasmota/raw/master/teleinfo/binary/tasmota32-teleinfo-ethernet.bin
 
-; Set auto timezone
-Backlog0 Timezone 99; TimeStd 0,0,10,1,3,60; TimeDst 0,0,3,1,2,120
+; Set serial log output to info on uart0 (log to onboard USB/Serial)
+Backlog SerialConfig 8N1; Baudrate 115200; SerialLog 2;
 
-; Set Teleinfo in legacy (historique) mode at 1200 baud.
-; EnergyConfig Historique	
+; Set default module
+Module 0
 
-; Set Teleinfo in standard mode at 9600 baud.
-; EnergyConfig Standard
-
-; Set Teleinfo to autodetect mode (standard or historique)
-; old firmware commnand, deprecated
-; Energyconfig automode 
-
-; Set serial log output to info
-SerialLog 2
-
-; Set Teleinfo to autodetect mode 
-Energyconfig reset 
 

--- a/raw/esp32/EthTinfo_V1.0/init.bat
+++ b/raw/esp32/EthTinfo_V1.0/init.bat
@@ -31,10 +31,8 @@ Energyconfig period=1 reset
 
 ; Set module configuration
 Template {"NAME":"EthTinfo (Olimex ESP32)","GPIO":[1,1,8864,1,0,1,0,0,5536,1,8832,8800,0,0,5600,1,1,1,1,5568,1,1,1,1,0,0,0,0,1,1,32,1,5632,1,1,1],"FLAG":0,"BASE":1}
-Module 0
-EthType 0
-EthAddress 0
-EthClockMode 3
+Backlog Ethernet 1; EthType 0; EthAddress 0; EthClockMode 3;
+
 
 ; Set LED brightness to 75%, in sleep mode it will be bright/2
 Energyconfig bright=75
@@ -42,8 +40,8 @@ Energyconfig bright=75
 ; OTA Url
 OtaUrl https://github.com/NicolasBernaerts/tasmota/raw/master/teleinfo/binary/tasmota32-teleinfo-ethernet.bin
 
-; Set serial log output to info on uart0 (log to onboard USB/Serial)
-Backlog SerialConfig 8N1; Baudrate 115200; SerialLog 2;
+; Set serial log output to info
+SerialLog 2;
 
 ; Set default module
 Module 0

--- a/raw/esp32/EthTinfo_V1.1/init.bat
+++ b/raw/esp32/EthTinfo_V1.1/init.bat
@@ -31,10 +31,7 @@ Energyconfig period=1 reset
 
 ; Set module configuration
 Template {"NAME":"EthTinfo (Olimex ESP32)","GPIO":[1,1,8864,1,0,1376,0,0,5536,1,8832,8800,0,0,5600,1,1,1,1,5568,1,1,1,1,0,0,0,0,1,1,32,1,5632,1,1,1],"FLAG":0,"BASE":1}
-Module 0
-EthType 0
-EthAddress 0
-EthClockMode 3
+Backlog Ethernet 1; EthType 0; EthAddress 0; EthClockMode 3;
 
 ; Set LED brightness to 75%, in sleep mode it will be bright/2
 Energyconfig bright=75
@@ -42,8 +39,8 @@ Energyconfig bright=75
 ; OTA Url
 OtaUrl https://github.com/NicolasBernaerts/tasmota/raw/master/teleinfo/binary/tasmota32-teleinfo-ethernet.bin
 
-; Set serial log output to info on uart0 (log to onboard USB/Serial)
-Backlog SerialConfig 8N1; Baudrate 115200; SerialLog 2;
+; Set serial log output to info
+SerialLog 2;
 
 ; Set default module
 Module 0

--- a/raw/esp32/EthTinfo_V1.1/init.bat
+++ b/raw/esp32/EthTinfo_V1.1/init.bat
@@ -1,37 +1,51 @@
+; Generic Teleinfo
+; ----------------
+
+; Reset settings, but preserve wifi, MQTT and FS
+InitDevice 6
+
+; Disable analog values display
+WebSensor2 0
+
+; Disable energy values display
+WebSensor3 0
+
+; Disable Boot Loop Detection
+SetOption65 1
+
+; Enable Wifi Scan (avoid wifi lost if router change channel)
+SetOption56 1
+
+; Set WebRefresh to 1 second
+WebRefresh 1000
+
+; Set auto timezone
+Backlog Timezone 99; TimeStd 0,0,10,1,3,60; TimeDst 0,0,3,1,2,120;
+
+; Set blinking LED color : 0 for Green LED and 1 for Period Indicator (blue, white or red)
+; Set Teleinfo to autodetect mode 
+Energyconfig period=1 reset
+
+; EthTinfo
+; --------
+
+; Set module configuration
 Template {"NAME":"EthTinfo (Olimex ESP32)","GPIO":[1,1,8864,1,0,1376,0,0,5536,1,8832,8800,0,0,5600,1,1,1,1,5568,1,1,1,1,0,0,0,0,1,1,32,1,5632,1,1,1],"FLAG":0,"BASE":1}
 Module 0
 EthType 0
 EthAddress 0
 EthClockMode 3
 
+; Set LED brightness to 75%, in sleep mode it will be bright/2
+Energyconfig bright=75
 
-; All these parameters are saved onto flash device
-; so once configured, you can change them afterward
-; in the file autoexec.be copied onto the filesystem
-; =====================================================
-
-; Disable Boot Loop Detection
-SetOption65 1
-
-; define OTA Url
+; OTA Url
 OtaUrl https://github.com/NicolasBernaerts/tasmota/raw/master/teleinfo/binary/tasmota32-teleinfo-ethernet.bin
 
-; Set auto timezone
-Backlog0 Timezone 99; TimeStd 0,0,10,1,3,60; TimeDst 0,0,3,1,2,120
+; Set serial log output to info on uart0 (log to onboard USB/Serial)
+Backlog SerialConfig 8N1; Baudrate 115200; SerialLog 2;
 
-; Set Teleinfo in legacy (historique) mode at 1200 baud.
-; EnergyConfig Historique	
+; Set default module
+Module 0
 
-; Set Teleinfo in standard mode at 9600 baud.
-; EnergyConfig Standard
-
-; Set Teleinfo to autodetect mode (standard or historique)
-; old firmware commnand, deprecated
-; Energyconfig automode 
-
-; Set serial log output to info
-SerialLog 2
-
-; Set Teleinfo to autodetect mode 
-Energyconfig reset 
 


### PR DESCRIPTION
Change order of init command because some that require reset set a flag that can trigger reset 250ms after,  and if all is not finished, the end of init.bat is never executed thanks to [@NicolasBernaerts](https://github.com/NicolasBernaerts)