### PR TITLE
tongou: add SY2 (TO-Q-SY2-JWM)

### DIFF
--- a/raw/esp32/tongou_TO-Q-SY2-JWM/init.bat
+++ b/raw/esp32/tongou_TO-Q-SY2-JWM/init.bat
@@ -1,0 +1,4 @@
+Template {"NAME":"tongou SY2","GPIO":[32,1,9312,1,1,320,1,1,9313,8160,3200,544,1,1,1,1,0,1,1,1,0,0,1,1,0,0,0,0,1,1,4736,1,1,0,0,1],"FLAG":0,"BASE":1}
+Module 0
+AdcParam1 2,40000,100000,3950,0
+OtaUrl https://ota.tasmota.com/tasmota32/release/tasmota32.bin


### PR DESCRIPTION
`tongou` (first letter is lower) `TO-Q-SY2-JWM` is ESP32 DIN rail 1-channel relay (previously discussed [here](https://github.com/arendst/Tasmota/discussions/23357)). 
It has external temperature sensor and it is required to change `AdcParam1` to `2,40000,100000,3950,0` to make it function correctly (it comes with tasmota, those params are taken from factory firmware)
